### PR TITLE
Fixes for cli scripts

### DIFF
--- a/packages/cli/src/commands/exec.js
+++ b/packages/cli/src/commands/exec.js
@@ -9,6 +9,7 @@ import { getPaths } from 'src/lib'
 import c from 'src/lib/colors'
 
 const runScript = async (scriptPath, scriptArgs) => {
+  // Import babel config for running script
   babelRequireHook({
     extends: path.join(getPaths().api.base, '.babelrc.js'),
     extensions: ['.js', '.ts'],

--- a/packages/cli/src/commands/exec.js
+++ b/packages/cli/src/commands/exec.js
@@ -8,30 +8,28 @@ import terminalLink from 'terminal-link'
 import { getPaths } from 'src/lib'
 import c from 'src/lib/colors'
 
-babelRequireHook({
-  extends: path.join(getPaths().api.base, '.babelrc.js'),
-  extensions: ['.js', '.ts'],
-  only: [getPaths().api.base],
-  plugins: [
-    ['ignore-html-and-css-imports'],
-    [
-      'babel-plugin-module-resolver',
-      {
-        alias: {
-          src: getPaths().api.src,
-        },
-      },
-    ],
-  ],
-  ignore: ['node_modules'],
-  cache: false,
-})
-
-const { db } = require(path.join(getPaths().api.lib, 'db'))
-
 const runScript = async (scriptPath, scriptArgs) => {
+  babelRequireHook({
+    extends: path.join(getPaths().api.base, '.babelrc.js'),
+    extensions: ['.js', '.ts'],
+    only: [getPaths().api.base],
+    plugins: [
+      [
+        'babel-plugin-module-resolver',
+        {
+          alias: {
+            src: getPaths().api.src,
+          },
+        },
+      ],
+    ],
+    ignore: ['node_modules'],
+    cache: false,
+  })
+
   const script = await import(scriptPath)
-  await script.default({ db, args: scriptArgs })
+  await script.default({ args: scriptArgs })
+  return
 }
 
 export const command = 'exec <name>'
@@ -81,9 +79,10 @@ export const handler = async (args) => {
 
   try {
     await tasks.run()
-    await db.$disconnect()
+
+    // We have to do this to terminate
+    process.exit(0)
   } catch (e) {
-    await db.$disconnect()
     console.error(c.error(`The script exited with errors.`))
     process.exit(e?.exitCode || 1)
   }

--- a/packages/cli/src/commands/generate/script/script.js
+++ b/packages/cli/src/commands/generate/script/script.js
@@ -12,7 +12,7 @@ const POST_RUN_INSTRUCTIONS = `Next steps...\n\n   ${c.warning(
   'After writing your script, you can run it with:'
 )}
 
-     yarn rw run <name>
+     yarn rw exec <name>
 `
 
 const TEMPLATE_PATH = path.resolve(__dirname, 'templates', 'script.js.template')

--- a/packages/cli/src/commands/generate/script/script.js
+++ b/packages/cli/src/commands/generate/script/script.js
@@ -2,23 +2,17 @@ import fs from 'fs'
 import path from 'path'
 
 import Listr from 'listr'
-import { paramCase } from 'param-case'
 import terminalLink from 'terminal-link'
+
+import { getProject } from '@redwoodjs/structure'
 
 import { getPaths, writeFilesTask } from 'src/lib'
 import c from 'src/lib/colors'
 
-const POST_RUN_INSTRUCTIONS = `Next steps...\n\n   ${c.warning(
-  'After writing your script, you can run it with:'
-)}
-
-     yarn rw exec <name>
-`
-
 const TEMPLATE_PATH = path.resolve(__dirname, 'templates', 'script.js.template')
 
-export const files = ({ name }) => {
-  const outputFilename = `${paramCase(name)}.js`
+export const files = ({ name, typescript }) => {
+  const outputFilename = `${name}.${typescript ? 'ts' : 'js'}`
   const outputPath = path.join(getPaths().api.scripts, outputFilename)
 
   return {
@@ -34,6 +28,13 @@ export const builder = (yargs) => {
       description: 'A descriptor of what this script does',
       type: 'string',
     })
+    .option('typescript', {
+      alias: 'ts',
+      description:
+        'Generate TypeScript file. Enabled by default if we detect your project is TypeScript',
+      type: 'boolean',
+      default: getProject().isTypeScriptProject,
+    })
     .epilogue(
       `Also see the ${terminalLink(
         'Redwood CLI Reference',
@@ -43,6 +44,15 @@ export const builder = (yargs) => {
 }
 
 export const handler = async (args) => {
+  const POST_RUN_INSTRUCTIONS = `Next steps...\n\n   ${c.warning(
+    'After modifying your script, you can invoke it like:'
+  )}
+
+     yarn rw exec ${args.name}
+
+     yarn rw exec ${args.name} --param1 true
+`
+
   const tasks = new Listr(
     [
       {

--- a/packages/cli/src/commands/generate/script/templates/script.js.template
+++ b/packages/cli/src/commands/generate/script/templates/script.js.template
@@ -1,6 +1,8 @@
 // Import files from your api workspace here
-import { db } from 'src/lib/db'
+import { db } from '../src/lib/db'
 
 export default async ({ args }) => {
   // Your script here...
+  console.log(':: Executing script with args ::')
+  console.log(args)
 }

--- a/packages/cli/src/commands/generate/script/templates/script.js.template
+++ b/packages/cli/src/commands/generate/script/templates/script.js.template
@@ -1,5 +1,6 @@
 // Import files from your api workspace here
+import { db } from 'src/lib/db'
 
-export default async ({ db, args }) => {
+export default async ({ args }) => {
   // Your script here...
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -17,6 +17,7 @@
     "@babel/core": "7.13.16",
     "@babel/node": "7.13.13",
     "@babel/plugin-proposal-class-properties": "7.13.0",
+    "@babel/plugin-proposal-private-methods": "7.13.0",
     "@babel/plugin-transform-runtime": "7.13.15",
     "@babel/preset-env": "7.13.15",
     "@babel/preset-react": "7.13.13",

--- a/packages/create-redwood-app/template/package.json
+++ b/packages/create-redwood-app/template/package.json
@@ -15,8 +15,8 @@
     "root": true
   },
   "engines": {
-    "node": ">=14 <16",
-    "yarn": ">=1.15"
+    "node": "14.x",
+    "yarn": "1.x"
   },
   "resolutions": {
     "react": "17.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -580,7 +580,7 @@
     "@babel/helper-skip-transparent-expression-wrappers" "^7.12.1"
     "@babel/plugin-syntax-optional-chaining" "^7.8.3"
 
-"@babel/plugin-proposal-private-methods@^7.12.1", "@babel/plugin-proposal-private-methods@^7.13.0":
+"@babel/plugin-proposal-private-methods@7.13.0", "@babel/plugin-proposal-private-methods@^7.12.1", "@babel/plugin-proposal-private-methods@^7.13.0":
   version "7.13.0"
   resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-private-methods/-/plugin-proposal-private-methods-7.13.0.tgz#04bd4c6d40f6e6bbfa2f57e2d8094bad900ef787"
   integrity sha512-MXyyKQd9inhx1kDYPkFRVOBXQ20ES8Pto3T7UZ92xj2mY0EVD8oAVzeyYuVfy/mxAdTSIayOvg+aVzcHV2bn6Q==


### PR DESCRIPTION
Adding in some extra fixes for https://github.com/redwoodjs/redwood/pull/2436

- Fix prerender being broken due to babelRequireHook
- Adds TypeScript support
- Slightly improves messaging
- File name generated is now consistent